### PR TITLE
CRC64 now adheres to Checksum interface. Tests were also added.

### DIFF
--- a/crc-64/src/main/java/net/boeckling/crc/CRC64.java
+++ b/crc-64/src/main/java/net/boeckling/crc/CRC64.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.zip.Checksum;
 
 /**
  * CRC-64 implementation with ability to combine checksums calculated over
@@ -19,7 +20,7 @@ import java.io.InputStream;
  * @author Roman Nikitchenko (roman@nikitchenko.dp.ua)
  * @author Michael Böckling
  */
-public class CRC64
+public class CRC64 implements Checksum
 {
 
     private final static long POLY = (long) 0xc96c5795d7870f42L; // ECMA-182
@@ -97,6 +98,22 @@ public class CRC64
     {
         this.value = 0;
         update(b, len);
+    }
+
+    /**
+     * Initialize by calculating the CRC of the given byte blocks.
+     *
+     * @param b
+     *            block of bytes
+     * @param off
+     *            starting offset of the byte block
+     * @param len
+     *            number of bytes to process
+     */
+    public CRC64(byte[] b, int off, int len)
+    {
+        this.value = 0;
+        update(b, off, len);
     }
 
     /**
@@ -181,13 +198,20 @@ public class CRC64
     /**
      * Update CRC64 with new byte block.
      */
-    public void update(byte[] b, int len)
+    public void update(byte[] b, int len) {
+        this.update(b, 0, len);
+    }
+
+    /**
+     * Update CRC64 with new byte block.
+     */
+    public void update(byte[] b, int off, int len)
     {
         this.value = ~this.value;
 
         /* fast middle processing, 8 bytes (aligned!) per loop */
 
-        int idx = 0;
+        int idx = off;
         while (len >= 8)
         {
             value = table[7][(int) (value & 0xff ^ (b[idx] & 0xff))]
@@ -211,6 +235,14 @@ public class CRC64
         }
 
         this.value = ~this.value;
+    }
+
+    public void update(int b) {
+        this.update(new byte[]{(byte)b}, 0, 1);
+    }
+
+    public void reset() {
+        this.value = 0;
     }
 
     // dimension of GF(2) vectors (length of CRC)

--- a/crc-64/src/test/java/net/boeckling/crc/CRC64Test.java
+++ b/crc-64/src/test/java/net/boeckling/crc/CRC64Test.java
@@ -101,6 +101,58 @@ public class CRC64Test
 
     /**
      *
+     */
+    @Test
+    public void testOffset()
+    {
+        final byte[] TEST1 = "12345678901".getBytes();
+        final int TESTOFF1 = 1;
+        final int TESTLEN1 = 9;
+
+        CRC64 crc1 = new CRC64(TEST1, TESTOFF1, TESTLEN1);
+        final long value1 = crc1.getValue();
+
+        final byte[] TEST2 = "234567890".getBytes();
+        final int TESTOFF2 = 0;
+        final int TESTLEN2 = 9;
+
+        CRC64 crc2 = new CRC64(TEST2, TESTOFF2, TESTLEN2);
+        final long value2 = crc2.getValue();
+
+        Assert.assertEquals("oh noes", value1, value2);
+    }
+
+    /**
+     *
+     */
+    @Test
+    public void testUpdateAndReset()
+    {
+        CRC64 crc = new CRC64();
+
+        final byte[] TEST1 = "123456789".getBytes();
+        final int TESTLEN1 = 9;
+        final long TESTCRC1 = 0x995dc9bbdf1939faL; // ECMA.
+
+        crc.update(TEST1, TESTLEN1);
+
+        Assert.assertEquals("oh noes", TESTCRC1, crc.getValue());
+
+        crc.reset();
+
+        Assert.assertEquals("oh noes", 0, crc.getValue());
+
+        final byte[] TEST2 = "This is a test of the emergency broadcast system.".getBytes();
+        final int TESTLEN2 = 49;
+        final long TESTCRC2 = 0x27db187fc15bbc72L; // ECMA.
+
+        crc.update(TEST2, TESTLEN2);
+
+        Assert.assertEquals("oh noes", TESTCRC2, crc.getValue());
+    }
+
+    /**
+     *
      * @param b
      * @param len
      * @param crcValue


### PR DESCRIPTION
Implementors of the Checksum interface includes CRC32 and Adler32. It seemed only fitting that CRC64 would also adhere to this interface.